### PR TITLE
fix: unable to start scan from a cron job

### DIFF
--- a/docker/scan.sh
+++ b/docker/scan.sh
@@ -2,7 +2,14 @@
 
 docker pull vuls/vuls
 
-docker run --rm -it\
+if [[ $(tty) =~ "not a tty" ]]
+then
+    t=''
+else
+    t="-t"
+fi
+
+docker run --rm -i $t \
     -v $HOME/.ssh:/root/.ssh:ro \
     -v $PWD:/vuls \
     vuls/vuls configtest \
@@ -15,7 +22,7 @@ if [ $ret -ne 0 ]; then
 	exit 1
 fi
 
-docker run --rm -it\
+docker run --rm -i $t \
     -v $HOME/.ssh:/root/.ssh:ro \
     -v $PWD:/vuls \
     vuls/vuls scan \


### PR DESCRIPTION
tty terminal is not available when running from a cronjob